### PR TITLE
Cope with @int128_str in the parser.

### DIFF
--- a/src/parser.jl
+++ b/src/parser.jl
@@ -431,7 +431,7 @@ function show_expr(io::IO, expr::Expr) # recursively unparse Julia expression
     elseif expr.head == :(::)
         show_expr(io,expr.args[1])
     elseif expr.head == :macrocall
-        if expr.args[1] == Symbol("@big_str")
+        if expr.args[1] == Symbol("@big_str") || expr.args[1] == Symbol("@int128_str")
             print(io,expr.args[2])
         else
             throw(ReduceError("Macro $(expr.args[1]) block structure not supported"))


### PR DESCRIPTION
I kept getting error messages saying `Macro @int128_str block structure not supported`. This should fix that.

The @big_str macro accepts everything that @int128_str does so we can use the code for that.