### PR TITLE
Merge `force-user` into `master`

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,11 +55,17 @@ For users who wish to experiment with precomplation, it is possible to enable ex
 
 View the documentation [stable](https://chakravala.github.io/Reduce.jl/stable) / [latest](https://chakravala.github.io/Reduce.jl/latest) for more features and examples.
 
+The extended algebraic symbolic expression mode of Reduce.jl is activated with [ForceImport.jl](https://github.com/chakravala/ForceImport.jl) by
+```Julia
+@force using Reduce.Algebra
+```
+Which locally extends many native Julia function to `Symbol` and `Expr` types without extending global methods.
+
 ## Usage
 
 Reduce expressions encapsulated into `RExpr` objects can be manipulated within julia using the standard syntax. Create an expression object either using the `RExpr("expression")` string constructor or `R"expression"`. Additionally, arbitrary julia expressions can also be parsed directly using the `RExpr(expr)` constructor. Internally `RExpr` objects are represented as an array that can be accessed by calling `*.str[n]` on the object.
 
-When `Reduce` is used in Julia, the standard arithmetic operations are now extended to also work on `Symbol` and `Expr` types.
+When `Reduce` is used in Julia, standard arithmetic operations are now extended to also work on `Symbol` and `Expr` types.
 ```Julia
 julia> 1-1/:n
 :((n - 1) // n)

--- a/README.md
+++ b/README.md
@@ -55,13 +55,13 @@ For users who wish to experiment with precomplation, it is possible to enable ex
 
 View the documentation [stable](https://chakravala.github.io/Reduce.jl/stable) / [latest](https://chakravala.github.io/Reduce.jl/latest) for more features and examples.
 
+## Usage
+
 The extended algebraic symbolic expression mode of Reduce.jl is activated with [ForceImport.jl](https://github.com/chakravala/ForceImport.jl) by
 ```Julia
 @force using Reduce.Algebra
 ```
-Which locally extends many native Julia function to `Symbol` and `Expr` types without extending global methods.
-
-## Usage
+This locally extends native Julia functions to `Symbol` and `Expr` types in the current module without extending global methods. Alternatively, the methods it provides can be accesed by prefixing `Algebra.` in front of the method.
 
 Reduce expressions encapsulated into `RExpr` objects can be manipulated within julia using the standard syntax. Create an expression object either using the `RExpr("expression")` string constructor or `R"expression"`. Additionally, arbitrary julia expressions can also be parsed directly using the `RExpr(expr)` constructor. Internally `RExpr` objects are represented as an array that can be accessed by calling `*.str[n]` on the object.
 

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,3 @@
 julia 0.6
 Compat 0.34
+ForceImport

--- a/src/Reduce.jl
+++ b/src/Reduce.jl
@@ -74,6 +74,15 @@ function ReduceCheck(output) # check for REDUCE errors
     contains(output,r"(([*]{5})|([+]{3}) )|( ?  \(Y or N\))") && throw(ReduceError(output))
 end
 
+function ReduceWarn(output) # check for REDUCE warnings
+    if contains(output,r"[*]{3}")
+        info("REDUCE: "*chomp(output))
+        join(split(output,r"[*]{3}.*\n"))
+    else
+        output
+    end
+end
+
 function PipeClogged(tf::Bool,c::Int,info::String)
     warn("Reduce pipe clogged by $info, $(tf ? "success" : "failure") after $c tries")
 end
@@ -98,7 +107,7 @@ function Base.read(rs::PSL) # get result and strip prompts/EOT char
     out = replace(replace(out,r"\$\n\n" => "\n\n"),RES=>"")
     out = replace(out,Regex(SOS) => "")
     ReduceCheck(out)
-    return out
+    return ReduceWarn(out)
 end
 
 readsp(rs::PSL) = split(read(rs),"\n\n\n")
@@ -219,6 +228,7 @@ function Load()
         rcall(R"on savestructr")
         show(DevNull,"text/latex",R"int(sinh(e**i*z),z)")
         R"x" == R"x"
+        ListPrint(0)
     end
     if isdefined(Base,:active_repl) && isinteractive()
         eval(s)

--- a/src/Reduce.jl
+++ b/src/Reduce.jl
@@ -1,5 +1,6 @@
 __precompile__()
 module Reduce
+using ForceImport
 using Compat; import Compat.String
 
 #   This file is part of Reduce.jl. It is licensed under the MIT license
@@ -107,13 +108,15 @@ include("parser.jl") # load parser generator
 include("repl.jl") # load repl features
 include("switch.jl") # load switch operators
 
-#=module Algebra
+module Algebra
 importall Reduce
 using Compat
-import Compat.String=#
+import Compat.String
 include("unary.jl") # load unary operators
 include("args.jl") # load calculus operators
-#end
+end
+
+export Algebra, @force
 
 Base.write(rs::PSL,r::RExpr) = write(rs,convert(Compat.String,r))
 

--- a/src/args.jl
+++ b/src/args.jl
@@ -48,7 +48,8 @@ const cmat = [
     :cofactor
 ]
 
-Expr(:toplevel,[:(import Base: $i) for i ∈ [alg;iops]]...) |> eval
+Expr(:block,[:($i(r...)=Base.$i(r...)) for i ∈ [alg;iops]]...) |> eval
+#Expr(:toplevel,[:(import Base: $i) for i ∈ [alg;iops]]...) |> eval
 :(export $([calculus;alg;iops;cmat]...)) |> eval
 #:(export $(Symbol.("@",[calculus;alg;iops])...)) |> eval
 

--- a/src/args.jl
+++ b/src/args.jl
@@ -25,6 +25,10 @@ const calculus = [
     :lterm,
     :reduct,
     :totaldeg,
+]
+
+const cnan = [
+    :clear,
     :matrix,
     :operator
 ]
@@ -50,7 +54,7 @@ const cmat = [
 
 Expr(:block,[:($i(r...)=Base.$i(r...)) for i ∈ [alg;iops]]...) |> eval
 #Expr(:toplevel,[:(import Base: $i) for i ∈ [alg;iops]]...) |> eval
-:(export $([calculus;alg;iops;cmat]...)) |> eval
+:(export $([calculus;cnan;alg;iops;cmat]...)) |> eval
 #:(export $(Symbol.("@",[calculus;alg;iops])...)) |> eval
 
 for fun in [calculus;alg;iops]
@@ -68,6 +72,13 @@ for fun in [calculus;alg]
         function $fun(expr::Compat.String,s...;be=0)
             convert(Compat.String, $fun(RExpr(expr),s...;be=be))
         end
+    end
+end
+
+for fun in cnan
+    @eval begin
+        $fun(r::RExpr...) = string($(string(fun)),"(",join(string.(r),","),")") |> rcall |> RExpr
+        $fun(r...) = $fun(RExpr.(r)...) |> parse
     end
 end
 

--- a/src/args.jl
+++ b/src/args.jl
@@ -14,8 +14,6 @@ const calculus = [
     :coeff,
     :coeffn,
     :part,
-    :realvalued,
-    :notrealvalued,
     :factorize,
     :remainder,
     :resultant,
@@ -25,12 +23,29 @@ const calculus = [
     :lterm,
     :reduct,
     :totaldeg,
+    :pochhammer,
 ]
 
 const cnan = [
     :clear,
     :matrix,
-    :operator
+    :operator,
+    :listargp,
+    :infix,
+    :precedence,
+    :depend,
+    :nodepend,
+    :realvalued,
+    :notrealvalued,
+    :set,
+    :unset,
+    :mkid,
+    :even,
+    :odd,
+    :linear,
+    :noncom,
+    :symmetric,
+    :antisymmetric,
 ]
 
 const alg = [

--- a/src/parser.jl
+++ b/src/parser.jl
@@ -568,7 +568,7 @@ end
             print_args(io,expr.args[2:end])
         end
     elseif expr.head == :(=)
-        if (typeof(expr.args[1]) == Expr) && (expr.args[1].head == :call)
+        if (typeof(expr.args[1]) == Expr) && (expr.args[1].head == :call) && ListPrint()<1
             show_expr(io,Expr(:function,expr.args[1],expr.args[2]))
         else
             show_expr(io,expr.args[1])
@@ -639,6 +639,16 @@ end
             print(io,",")
         end
         print(io,expr.args[end])
+    elseif expr.head == :tuple
+        ListPrint(ListPrint()+1)
+        print(io,"{")
+        l = length(expr.args)
+        for i ∈ 1:l
+            show_expr(io,expr.args[i])
+            i ≠ l && print(io,",")
+        end
+        print(io,"}")
+        ListPrint(ListPrint()-1)
     elseif expr.head == :line; nothing
     else
         throw(ReduceError("Nested :$(expr.head) block structure not supported"))

--- a/src/parser.jl
+++ b/src/parser.jl
@@ -190,9 +190,14 @@ for mode ∈ [:expr,:unary,:switch,:args]
                                 push!(args, af≠[nothing] ? af : Array{Any,1}(0))
                             end
                         end
-                        length(args)==1 && typeof(args[1]) <: Array && (args = args[1])
-                        push!(nsr,args)
+                        length(args)==1 && typeof(args[1]) <: Tuple && (args = args[1])
+                        push!(nsr,Tuple(args))
                     end; else; :(nothing); end)
+                elseif contains($((mode == :expr) ? :(sexpr[h]) : :("")),"=>")
+                    sp = split(sexpr[h],r"=>")
+                    stuff = String.(split(sp[2],r"(when)|(and)"))
+                    ar = $rfun.(fun,stuff;be=be)
+                    push!(nsr,$rfun(fun,sp[1];be=be) => length(ar) ≠ 1 ? ar : ar[1])
                 elseif contains($((mode == :expr) ? :(sexpr[h]) : :("")),prefix)
                     $(if mode == :expr; quote
                     ts = sexpr[h]
@@ -395,7 +400,7 @@ end
 Parser generator that outputs code to walk and manipulate REDUCE expressions
 """
 function parsegen(fun::Symbol,mode::Symbol)
-    fune = fun == :// ? :/ : fun
+    fune = (fun == ://) ? :/ : (fun == :rlet) ? :let : fun
     mf = Symbol(:parse,"_",mode)
     a = mode != :args ? [:(r::RExpr)] : [:(r::RExpr),Expr(:...,:s)]
     return mode ≠ :expr ? :($fun($(a...);be=0) = $mf($(string(fune)),$(a...);be=0)) :
@@ -567,7 +572,7 @@ end
             show_expr(io,Expr(:function,expr.args[1],expr.args[2]))
         else
             show_expr(io,expr.args[1])
-            print(io,":=")
+            print(io,ListPrint()>0 ? "=" : ":=")
             show_expr(io,expr.args[2])
         end
     elseif contains(string(expr.head),r"[*\/+-^]=$")
@@ -575,7 +580,7 @@ end
             throw(ReduceError("function assignment for $(expr.head) not supported"))
         else
             show_expr(io,expr.args[1])
-            print(io,":=")
+            print(io,ListPrint()>0 ? "=" : ":=")
             print(io,match(r"[^(=$)]",string(expr.head)).match*"(")
             show_expr(io,expr.args[1])
             print(io,",")
@@ -685,6 +690,28 @@ function show_expr(io::IO, ex)
             i ≠ l && print(io,",")
         end
         print(io,"))")
+    elseif typeof(ex) <: Tuple
+        ListPrint(ListPrint()+1)
+        print(io,"{")
+        l = length(ex)
+        for i ∈ 1:l
+            show_expr(io,ex[i])
+            i ≠ l && print(io,",")
+        end
+        print(io,"}")
+        ListPrint(ListPrint()-1)
+    elseif typeof(ex) <: Pair
+        show_expr(io,ex[1])
+        print(io," => ")
+        if typeof(ex[2]) <: Array
+            show_expr(io,ex[2][1])
+            for k ∈ 2:length(ex[2])
+                print(io, k ≠ 1 ? " and " : " when ")
+                show_expr(io, ex[2][k])
+            end
+        else
+            show_expr(io,ex[2])
+        end
     elseif typeof(ex) <: Array
         if length(size(ex)) > 2
             throw(ReduceError("parsing of $(typeof(ex)) not supported."))

--- a/src/rexpr.jl
+++ b/src/rexpr.jl
@@ -200,7 +200,7 @@ sub(s::Array{<:Pair{<:Any,<:Any},1},expr) = sub(Dict(s...),expr)
 """
     sub(T::DataType,expr::Expr)
 
-Make a substitution to conver numerical values to type T
+Make a substitution to convert numerical values to type T
 """
 function sub(T::DataType,ixpr)
     if typeof(ixpr) == Expr
@@ -507,10 +507,10 @@ Reduces an entire program statement block using symbolic rewriting
 """
 function squash(expr)
     typeof(expr) == Expr && if expr.head == :block
-        return @eval $expr
+        return @eval Reduce.Algebra $expr
     elseif expr.head == :function
         out = deepcopy(expr)
-        out.args[2] = @eval $(Expr(:block,expr.args[2]))
+        out.args[2] = @eval Reduce.Algebra $(Expr(:block,expr.args[2]))
         return out
     else
         return rcall(expr)

--- a/src/switch.jl
+++ b/src/switch.jl
@@ -41,7 +41,18 @@ const switches = [
     :roundbf,
     :adjprec,
     :roundall,
-    :balancedmod
+    :balancedmod,
+    :nocommutedf,
+    :commutedf,
+    :simpnoncomdf,
+    :expanddf,
+    :allowdfint,
+    :dfint,
+    :trint,
+    :trintsubst,
+    :failhard,
+    :nolnr,
+    :nointsubst,
 ]
 
 const switchtex = [

--- a/src/unary.jl
+++ b/src/unary.jl
@@ -128,7 +128,8 @@ const smat = [
     :tp,
 ]
 
-Expr(:toplevel,[:(import Base: $i) for i ∈ [sbas;sdep;sbat;[:length]]]...) |> eval
+Expr(:block,[:($i(r...)=Base.$i(r...)) for i ∈ [sbas;sdep;sbat;[:length]]]...) |> eval
+#Expr(:toplevel,[:(import Base: $i) for i ∈ [sbas;sdep;sbat;[:length]]]...) |> eval
 :(export $([sbas;sdep;sfun;snum;scom;sint;sran;sbat;smat;[:length]]...)) |> eval
 #:(export $(Symbol.("@",[sbas;sdep;sfun;snum;scom;sint])...)) |> eval
 

--- a/src/unary.jl
+++ b/src/unary.jl
@@ -83,7 +83,6 @@ const sfun = [
     :solidharmonicy,
     :sphericalharmonicy,
     :expand_cases,
-    :depend,
     :arglength,
     :decompose,
     :num,
@@ -93,6 +92,7 @@ const sfun = [
     :setmod,
     :rootval,
     :showrules,
+    :reverse,
 ]
 
 const snan = [

--- a/src/unary.jl
+++ b/src/unary.jl
@@ -128,7 +128,7 @@ const smat = [
     :tp,
 ]
 
-Expr(:block,[:($i(r...)=Base.$i(r...)) for i ∈ [sbas;sdep;sbat;[:length]]]...) |> eval
+Expr(:block,[:($i(r)=Base.$i(r)) for i ∈ [sbas;sdep;sbat;[:length]]]...) |> eval
 #Expr(:toplevel,[:(import Base: $i) for i ∈ [sbas;sdep;sbat;[:length]]]...) |> eval
 :(export $([sbas;sdep;sfun;snum;scom;sint;sran;sbat;smat;[:length]]...)) |> eval
 #:(export $(Symbol.("@",[sbas;sdep;sfun;snum;scom;sint])...)) |> eval

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,6 @@
 using Reduce, Compat
 using Base.Test
+@force using Reduce.Algebra
 
 # write your own tests here
 @test showerror(STDOUT,ReduceError("A Portable General-Purpose Computer Algebra System")) == nothing


### PR DESCRIPTION
This pull-request transitions the methods that previously globally extended Julia `Base` methods into a new sub-module called `Algebra`, which can be loaded using `@force using Reduce.Algebra`. See  #8.