### PR TITLE
Fix Preload() for Julia 1.5

### DIFF
--- a/src/Reduce.jl
+++ b/src/Reduce.jl
@@ -318,7 +318,7 @@ Reduce (Free PSL version, revision 4015),  5-May-2017 ...
 ```
 """
 Reset() = (kill(rs); Load())
-__init__() = (Load(); atexit(() -> kill(rs)))
+__init__() = (Load(); repl_init(); atexit(() -> kill(rs)))
 
 # Server setup
 
@@ -342,19 +342,6 @@ function Load()
     load_package(:rlfi)
     offs |> RExpr |> rcall
     rcall(R"on savestructr")
-
-    if isinteractive()
-        if isdefined(Base,:active_repl)
-            repl_init(Base.active_repl)
-        else
-            atreplinit() do repl
-                !isdefined(Main,:OhMyREPL) &&
-                    (repl.interface = Base.REPL.setup_interface(repl))
-                repl_init(Base.active_repl)
-                print('\n')
-            end
-        end
-    end
     return nothing
 end
 

--- a/src/Reduce.jl
+++ b/src/Reduce.jl
@@ -344,15 +344,16 @@ function Load()
     offs |> RExpr |> rcall
     rcall(R"on savestructr")
 
-    if isdefined(Base,:active_repl) && isinteractive()
-        repl_init(Base.active_repl)
-    elseif isdefined(Main,:IJulia)
-    else
-        atreplinit() do repl
-            !isdefined(Main,:OhMyREPL) &&
-                (repl.interface = Base.REPL.setup_interface(repl))
+    if isinteractive()
+        if isdefined(Base,:active_repl)
             repl_init(Base.active_repl)
-            print('\n')
+        else
+            atreplinit() do repl
+                !isdefined(Main,:OhMyREPL) &&
+                    (repl.interface = Base.REPL.setup_interface(repl))
+                repl_init(Base.active_repl)
+                print('\n')
+            end
         end
     end
     return nothing

--- a/src/Reduce.jl
+++ b/src/Reduce.jl
@@ -335,11 +335,10 @@ function Load()
     rcsl = occursin(" CSL ",banner)
     if Sys.iswindows()
         banner = replace(banner,r"\r" => "")
-        println(split(String(banner),'\n')[rcsl ? 1 : end-3])
     else
         ReduceCheck(banner)
-        println(split(String(banner),'\n')[rcsl ? 1 : end-3])
     end
+    global banner = split(String(banner),'\n')[rcsl ? 1 : end-3]
     load_package(:rlfi)
     offs |> RExpr |> rcall
     rcall(R"on savestructr")

--- a/src/Reduce.jl
+++ b/src/Reduce.jl
@@ -327,7 +327,6 @@ function Load()
 
     offs = ""
     for o in offlist
-        global offs
         o != :nat && (offs = offs*"off $o; ")
     end
     write(rs.input,"off nat; $EOTstr;\n")

--- a/src/Reduce.jl
+++ b/src/Reduce.jl
@@ -343,9 +343,6 @@ function Load()
     load_package(:rlfi)
     offs |> RExpr |> rcall
     rcall(R"on savestructr")
-    show(devnull,"text/latex",R"int(sinh(e**i*z),z)")
-    R"x" == R"x"
-    ListPrint(0)
 
     if isdefined(Base,:active_repl) && isinteractive()
         repl_init(Base.active_repl)

--- a/src/Reduce.jl
+++ b/src/Reduce.jl
@@ -358,32 +358,6 @@ function Load()
     return nothing
 end
 
-function Preload()
-    global rs=PSL()
-    offs = ""
-    for o in offlist
-        o != :nat && (offs = offs*"off $o; ")
-    end
-    write(rs.input,"off nat; $EOTstr;\n")
-    banner = readuntil(rs.output,EOT) |> String
-    readavailable(rs.output)
-    rcsl = occursin(" CSL ",banner)
-    if Sys.iswindows()
-        banner = replace(banner,r"\r" => "")
-        println(split(String(banner),'\n')[rcsl ? 1 : end-3])
-    else
-        ReduceCheck(banner)
-        println(split(String(banner),'\n')[rcsl ? 1 : end-3])
-    end
-    load_package(:rlfi)
-    offs |> RExpr |> rcall
-    rcall(R"on savestructr")
-    show(devnull,"text/latex",R"int(sinh(e**i*z),z)")
-    R"x" == R"x"
-    ListPrint(0)
-    atexit(()->kill(rs))
-end
-
 global preload = false
 try
     global preload

--- a/src/Reduce.jl
+++ b/src/Reduce.jl
@@ -322,7 +322,9 @@ __init__() = (Load(); atexit(() -> kill(rs)))
 
 # Server setup
 
-const s = quote; #global rs = PSL()
+function Load()
+    global rs = PSL()
+
     offs = ""
     for o in offlist
         global offs
@@ -345,19 +347,12 @@ const s = quote; #global rs = PSL()
     show(devnull,"text/latex",R"int(sinh(e**i*z),z)")
     R"x" == R"x"
     ListPrint(0)
-end
 
-function Load()
-    global rs = PSL()
-    global s
     if isdefined(Base,:active_repl) && isinteractive()
-        eval(s)
         repl_init(Base.active_repl)
     elseif isdefined(Main,:IJulia)
-        eval(s)
     else
         atreplinit() do repl
-            eval(s)
             !isdefined(Main,:OhMyREPL) &&
                 (repl.interface = Base.REPL.setup_interface(repl))
             repl_init(Base.active_repl)

--- a/src/precomp.jl
+++ b/src/precomp.jl
@@ -1,6 +1,6 @@
 global rs = nothing
 @info "Precompiling extra Reduce methods (set `ENV[\"REDPRE\"]=\"0\"` to disable)"
-Reduce.Preload(); atexit(() -> kill(rs))
+Reduce.Load(); atexit(() -> kill(rs))
 
 rcall(:((1+pi)^2)) == convert(Expr,RExpr(rcall("(1+pi)**2")))
 try; "1/0" |> rcall; false; catch; true; end

--- a/src/repl.jl
+++ b/src/repl.jl
@@ -53,3 +53,18 @@ function repl_init(repl)
         startup_text=false,
     )
 end
+
+function repl_init()
+    if isinteractive()
+        if isdefined(Base,:active_repl)
+            repl_init(Base.active_repl)
+        else
+            atreplinit() do repl
+                !isdefined(Main,:OhMyREPL) &&
+                    (repl.interface = Base.REPL.setup_interface(repl))
+                repl_init(Base.active_repl)
+                print('\n')
+            end
+        end
+    end
+end

--- a/src/repl.jl
+++ b/src/repl.jl
@@ -50,5 +50,6 @@ function repl_init(repl)
         start_key='}',
         mode_name="REDUCE",
         repl=repl,
+        startup_text=false,
     )
 end


### PR DESCRIPTION
I also had a similar issue as discussed in #32 and here is my take to fix it.

- A [blocker](https://github.com/chakravala/Reduce.jl/issues/32#issuecomment-670490854) seems to be `@eval` triggered by `R"x" == R"x"` during initialization() and I wasn't sure if this was really needed. So I removed it.
- Instead of `eval(s)`, the same code is now running in `Load()` directly. Not sure if there's any downside with it.
- Then separate `Preload()` is no longer needed since it's now identical to `Load()`, hence removed.
- Make sure custom REPL handler is installed only when `isinteractive()` is true.
- As an extra, a banner of version string is no longer displayed by default, but stored in `Reduce.banner` global variable. I found it somewhat obtrusive when using Reduce.jl as a dependency to other package.
- Similarly, REPL startup message is no longer displayed. REPL mode selection with `'{'` still works.
- Make sure REPL gets initialized only once in `__init__()` to not trigger keybinding overwrite warning from `Reset()`.

That particular example in #32 now seems to work fine on my Julia 1.5.1.

```
julia> module DebugModule

       using ForceImport
       @force using Reduce.Algebra
       using ReduceLinAlg


       f(a,b) = (:x - a) * (:x - b)
       g(a,b) = int( f(a,b), :x)

       # comment this out and the module loads,  or simply copy and paste the code
       # and it works
       g0 = g(:a,:b) - sub( (:(x=b), ), g(:a,:b))

       end # module
REPL mode REDUCE initialized. Press } to enter and backspace to exit.
Main.DebugModule

julia> DebugModule.g0
:(-((((3b - 2x) * x - 3 * (2b - x) * a) * x + (3a - b) * b ^ 2)) / 6)
```

`]test Reduce` seems to pass okay with a warning which I'm not sure if it has something to do with this modification.
```
(@v1.5) pkg> test Reduce
    Testing Reduce
Status `/private/var/folders/vt/fq5q103n6bb2kvwv0bg9wyyr0000gn/T/jl_5JhBGL/Project.toml`
  [a8e43f4a] AbstractTensors v0.5.3
  [9dda63f9] ForceImport v0.0.3
  [93e0c654] Reduce v1.2.8 `~/.julia/dev/Reduce`
  [b873ce64] ReplMaker v0.2.3
  [a4af3ec5] SyntaxTree v1.0.1
  [37e2e46d] LinearAlgebra
  [3fa0cd96] REPL
  [8dfed614] Test
Status `/private/var/folders/vt/fq5q103n6bb2kvwv0bg9wyyr0000gn/T/jl_5JhBGL/Manifest.toml`
  [398f06c4] AbstractLattices v0.2.1
  [a8e43f4a] AbstractTensors v0.5.3
  [9dda63f9] ForceImport v0.0.3
  [93e0c654] Reduce v1.2.8 `~/.julia/dev/Reduce`
  [b873ce64] ReplMaker v0.2.3
  [a4af3ec5] SyntaxTree v1.0.1
  [2a0f44e3] Base64
  [8ba89e20] Distributed
  [b77e0a4c] InteractiveUtils
  [8f399da3] Libdl
  [37e2e46d] LinearAlgebra
  [56ddb016] Logging
  [d6f4376e] Markdown
  [3fa0cd96] REPL
  [9a3f8284] Random
  [9e88b42a] Serialization
  [6462fe0b] Sockets
  [8dfed614] Test
  [4ec0a83e] Unicode
Reduce: A Portable General-Purpose Computer Algebra System
       3
(i + x)
\begin{eqnarray}

{\mathrm{cosh}} \left(e^{i} z\right)/e^{i}


\end{eqnarray}
┌ Info: REDUCE:
└ *** x already defined as operator
┌ Warning: Reduce pipe clogged by det function, failure after 17 tries
└ @ Reduce ~/.julia/dev/Reduce/src/Reduce.jl:73
    Testing Reduce tests passed
```

As I'm not really familiar with REDUCE yet, testing was very limited on my side. Please have a look and let me know if there's something broken.